### PR TITLE
'gem sandbox list' command

### DIFF
--- a/lib/rubygems/commands/sandbox_command.rb
+++ b/lib/rubygems/commands/sandbox_command.rb
@@ -49,6 +49,7 @@ popular command-tools like rdoc, flog, flay, rcov, etc.
 
   * install   gem_name ...             - install 1 or more gems
   * plugin    gem_name plugin_name ... - install a gem and plugins for it
+  * list                               - list sandboxed gems
   * uninstall gem_name ...             - uninstall 1 or more gems
   * help                               - show this output
 
@@ -73,6 +74,8 @@ and you're good to go.
       plugin
     when "uninstall" then
       abort "not implemented yet"
+    when "list" then
+      list
     when "help", "usage" then
       show_help
       abort
@@ -114,6 +117,20 @@ and you're good to go.
 
   def sandbox_dir gem_name
     File.join Gem.user_home, '.gem', "sandboxes", gem_name
+  end
+
+  def list
+    say ""
+    say "Sandboxed gems:"
+    Dir[sandbox_dir('*')].each do |path|
+      # This is totally a giant hack, but I don't know gem internals well
+      # enough to look it up properly
+      gem = File.split(path).last
+      gemdir = Dir[File.join path, 'gems', "#{gem}-*"].first
+      version = gemdir.match(/([\d.]+)$/)[1]
+      # TODO: gem list includes "ruby" after the version, probably useful info
+      say "#{gem} (#{version})"
+    end
   end
 
   def install_gem gem_name, dir = sandbox_dir(gem_name)


### PR DESCRIPTION
Adds a command to list the sandboxes installed, along with the version of the main gem.

Fixes Issue #1 that I had filed.
